### PR TITLE
Add SecretNote section, SEO updates, and CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - work
+      - feat/**
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test

--- a/index.html
+++ b/index.html
@@ -3,6 +3,22 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Cantinho da Lari é um espaço cheio de carinho com lembretes, memórias, música e mensagens especiais criadas sob medida para ela.">
+    <meta name="keywords" content="Cantinho da Lari, amor, lembretes, frases do dia, cantinho especial">
+    <meta name="author" content="Cantinho da Lari">
+    <meta name="robots" content="index, follow">
+    <meta name="theme-color" content="#d63384">
+    <link rel="canonical" href="https://cantinho-da-lari.netlify.app/">
+    <meta property="og:title" content="Cantinho da Lari">
+    <meta property="og:description" content="Um espaço carinhoso com surpresas, memórias e declarações feitas para a Lari.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://cantinho-da-lari.netlify.app/">
+    <meta property="og:image" content="https://cantinho-da-lari.netlify.app/larissa.png">
+    <meta property="og:locale" content="pt_BR">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Cantinho da Lari">
+    <meta name="twitter:description" content="Um cantinho inteiro dedicado a cuidar, mimar e surpreender a Lari.">
+    <meta name="twitter:image" content="https://cantinho-da-lari.netlify.app/larissa.png">
     <title>Cantinho da Lari</title>
     <link rel="stylesheet" href="style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -32,6 +48,7 @@
     <a href="#cantinho-lembrancas" class="nav-button">Lembranças</a>
     <a href="#cantinho-coisometro" class="nav-button">Coisômetro</a>
     <a href="#cantinho-musical" class="nav-button">Músicas</a>
+    <a href="#cantinho-secret-note" class="nav-button">Segredinhos</a>
     <a href="#cantinho-aleatoriedade" class="nav-button">Aleatoriedade</a>
     <a href="#cantinho-memes" class="nav-button">Memes</a>
 </nav>
@@ -113,10 +130,27 @@
         <button id="play-porta-retrato" class="btn-play-heart" aria-label="Tocar Porta Retrato">❤️</button>
     </div>
 </div>
-<!-- Botão Voltar ao Topo -->
-<a href="#topo" class="btn-voltar-topo" aria-label="Voltar ao topo">
-    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V5M5 12l7-7 7 7"/></svg>
-</a>
+            <!-- Botão Voltar ao Topo -->
+            <a href="#topo" class="btn-voltar-topo" aria-label="Voltar ao topo">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V5M5 12l7-7 7 7"/></svg>
+            </a>
+            </section>
+
+            <section class="card" id="cantinho-secret-note">
+                <h2>🔐 SecretNote 🔐</h2>
+                <p>Guarde aqui um bilhetinho secreto só seu. Quando a saudade apertar, é só abrir e reler com calma.</p>
+                <textarea id="secret-note-textarea" placeholder="Escreva seu segredinho mais doce aqui..."></textarea>
+                <div class="secret-note-actions">
+                    <button id="secret-note-save" class="btn">Guardar segredinho</button>
+                    <button id="secret-note-clear" class="btn btn-outline">Apagar tudo</button>
+                    <button id="secret-note-reveal" class="btn btn-positivo" aria-pressed="false">Mostrar segredinho</button>
+                </div>
+                <div id="secret-note-display" class="secret-note-display" aria-live="polite"></div>
+                <p id="secret-note-feedback" class="feedback-final" aria-live="polite"></p>
+                <!-- Botão Voltar ao Topo -->
+                <a href="#topo" class="btn-voltar-topo" aria-label="Voltar ao topo">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V5M5 12l7-7 7 7"/></svg>
+                </a>
             </section>
             <section class="card" id="cantinho-aleatoriedade">
     <h2>🎲 Cantinho da aLARIeatoriedade 🎲</h2>

--- a/package.json
+++ b/package.json
@@ -1,4 +1,11 @@
 {
+  "name": "cantinho-da-lari",
+  "version": "1.0.0",
+  "description": "Site especial cheio de carinho para o Cantinho da Lari",
+  "scripts": {
+    "lint": "node --check script.js",
+    "test": "npm run lint"
+  },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
     "@supabase/supabase-js": "^2.50.0"

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+
+# Atualize a linha abaixo com o endereço correto do sitemap assim que ele estiver disponível.
+# Sitemap: https://cantinho-da-lari.netlify.app/sitemap.xml

--- a/script.js
+++ b/script.js
@@ -8,19 +8,151 @@ window.addEventListener('DOMContentLoaded', () => {
 
 
     // --- SEÇÃO DO CONTADOR DE DIAS ---
-    const dataInicio = new Date(2024, 9, 24); // 24 de Outubro de 2024 (mês 9 é Outubro)
-    const hoje = new Date();
-    const diferencaEmMilissegundos = hoje - dataInicio;
-    const umDiaEmMilissegundos = 1000 * 60 * 60 * 24;
-    const diasPassados = Math.floor(diferencaEmMilissegundos / umDiaEmMilissegundos);
-    contadorEl.textContent = `Já se passaram ${diasPassados} dias desde nosso comecinho ❤️`;
+    const MS_POR_SEGUNDO = 1000;
+    const MS_POR_MINUTO = MS_POR_SEGUNDO * 60;
+    const MS_POR_HORA = MS_POR_MINUTO * 60;
+    const umDiaEmMilissegundos = MS_POR_HORA * 24;
+    const dataInicio = new Date(2024, 9, 24, 0, 0, 0); // 24 de Outubro de 2024 (mês 9 é Outubro)
+
+    const atualizarContador = () => {
+        if (!contadorEl) {
+            return;
+        }
+
+        const agora = new Date();
+        let diferencaEmMilissegundos = agora - dataInicio;
+        const eventoNoPassado = diferencaEmMilissegundos >= 0;
+        diferencaEmMilissegundos = Math.abs(diferencaEmMilissegundos);
+
+        const dias = Math.floor(diferencaEmMilissegundos / umDiaEmMilissegundos);
+        let restante = diferencaEmMilissegundos % umDiaEmMilissegundos;
+        const horas = Math.floor(restante / MS_POR_HORA);
+        restante %= MS_POR_HORA;
+        const minutos = Math.floor(restante / MS_POR_MINUTO);
+        restante %= MS_POR_MINUTO;
+        const segundos = Math.floor(restante / MS_POR_SEGUNDO);
+
+        const unidades = [
+            { valor: dias, singular: 'dia', plural: 'dias' },
+            { valor: horas, singular: 'hora', plural: 'horas' },
+            { valor: minutos, singular: 'minuto', plural: 'minutos' },
+            { valor: segundos, singular: 'segundo', plural: 'segundos' }
+        ];
+
+        const partes = unidades
+            .filter((unidade, index) => unidade.valor > 0 || index === unidades.length - 1)
+            .map(unidade => {
+                const { valor, singular, plural } = unidade;
+                const textoUnidade = valor === 1 ? singular : plural;
+                return `${valor} ${textoUnidade}`;
+            });
+
+        let tempoFormatado = partes.join(', ');
+        if (partes.length > 1) {
+            const ultimaParte = partes.pop();
+            tempoFormatado = `${partes.join(', ')} e ${ultimaParte}`;
+        }
+
+        contadorEl.textContent = eventoNoPassado
+            ? `Já se passaram ${tempoFormatado} desde 24/10/2024 ❤️`
+            : `Faltam ${tempoFormatado} para 24/10/2024 ❤️`;
+    };
+
+    atualizarContador();
+    setInterval(atualizarContador, 1000);
 
 
     // --- SEÇÃO DA FRASE DO DIA ---
+    const hoje = new Date();
     const frases = ["Às vezes, de longe parece que as coisas estão ruins, mas vendo de perto, parece que estão longe.", "Malandro é o gato, que já nasce de bigode.", "Em terra de saci, qualquer chute é uma voadora.", "A vida é como um sanduíche: o recheio é você quem escolhe.", "Se a vida te der limões, procure quem tem uma cachaça e um açúcar.", "Não sou o Google, mas em você eu encontro tudo que procuro.", "O importante não é saber, mas ter o telefone de quem sabe.", "Quem ri por último, não entendeu a piada.", "A pressa é a inimiga da refeição.", "Fui fazer o Enem e descobri que meu forte é interpretação de boleto.", "Malandro mesmo é o pato, que já nasce com os dedo colado pra não usar aliança.", "Se tudo na vida é passageiro, eu sou o cobrador.", "O futuro a Deus pertence, e a fatura do cartão a mim.", "Água mole em pedra dura, tanto bate até que... molha tudo.", "Não leve a vida tão a sério, afinal, você não vai sair vivo dela.", "Quem com ferro fere, não sabe a dor que eu sinto.", "Só não compro uma Ferrari porque não gosto da cor.", "Errar é humano, colocar a culpa nos outros é estratégia.", "O trabalho dignifica o homem, mas o cansaço que dá é uma vergonha.", "Deus ajuda quem cedo madruga, mas quem tarde madruga já pega o café pronto.", "Mais vale um pássaro na mão do que... ué, cadê meu relógio?", "A esperança é a última que morre, mas a minha paciência já foi faz tempo.", "Quem tem boca vai a Roma. Quem tem grana vai pra onde quiser.", "Não sou vidente, mas prevejo que amanhã é outro dia.", "A beleza interior é importante, mas uma chapinha também ajuda.", "Se o amor é cego, o negócio é apalpar.", "Se ferradura desse sorte, burro não puxava carroça.", "Quem cedo madruga, fica com sono o dia todo.", "Malandro é o goleiro, que joga onde os outros só trabalham.", "Depois da tempestade, vem a conta da reforma do telhado.", "Haverá um dia em que os robôs serão tão inteligentes que poderão nos dominar. Mas não hoje. Hoje eles só aspiram o chão.", "Em briga de saci, uma rasteira derruba.", "Se te jogarem pedras, construa um muro e venda os tijolos.", "A voz do povo é a voz de Deus, mas o povo anda muito desafinado.", "A vida te derruba, mas você pode escolher se levanta ou se tira um cochilo.", "Para que levar a vida a sério, se nós nascemos de uma gozada?", "Se conselho fosse bom, não se dava, se vendia. E o meu estaria em promoção.", "A fé move montanhas, mas eu prefiro usar um trator.", "Quem não tem cão, caça com... o vizinho reclamando do barulho.", "Diga-me com quem andas e eu te direi se vou junto.", "Se a montanha não vem a Maomé, Maomé pede um iFood.", "Eu não tenho problema com a segunda-feira, meu problema é com o trabalho.", "A mente é como um paraquedas, só funciona se estiver aberta.", "Quem espera sempre alcança, mas geralmente chega atrasado.", "Onde há fumaça, há... um churrasco começando.", "Se a vida é uma festa, eu nasci na cozinha lavando a louça.", "Roupa suja se lava em casa. A minha eu levo na lavanderia.", "Um dia a gente ri, no outro a gente é o meme.", "Não deixe para amanhã o que você pode deixar pra lá de vez.", "A diferença entre a genialidade e a estupidez é que a genialidade tem seus limites.", "Eu queria ser uma abelha, pra te dar uma ferroada no coração.", "Quem planta vento, colhe uma rinite alérgica.", "Se Maomé não vai à montanha, é porque a passagem de avião está muito cara.", "Gentileza gera gentileza, e um PIX também.", "De grão em grão, a galinha enche o papo e eu encho meu bucho.", "Quem não chora não mama, e quem chora demais já é adulto.", "Filho de peixe, peixinho é. A não ser que seja o Aquaman.", "Crie uma cobra e ela te picará. Crie um humano e ele... bom, ele também.", "Por trás de um grande homem, sempre há uma mulher surpresa.", "Quem cala consente, ou tá só esperando a vez de falar."];
     const diaDoAno = Math.floor((hoje - new Date(hoje.getFullYear(), 0, 0)) / umDiaEmMilissegundos);
     const indiceDiario = diaDoAno % frases.length;
     document.getElementById('frase-do-dia-texto').textContent = frases[indiceDiario];
+
+
+    // --- SEÇÃO DO SECRETNOTE ---
+    const secretNoteTextarea = document.getElementById('secret-note-textarea');
+    const secretNoteSaveBtn = document.getElementById('secret-note-save');
+    const secretNoteClearBtn = document.getElementById('secret-note-clear');
+    const secretNoteRevealBtn = document.getElementById('secret-note-reveal');
+    const secretNoteDisplay = document.getElementById('secret-note-display');
+    const secretNoteFeedback = document.getElementById('secret-note-feedback');
+
+    if (
+        secretNoteTextarea &&
+        secretNoteSaveBtn &&
+        secretNoteClearBtn &&
+        secretNoteRevealBtn &&
+        secretNoteDisplay &&
+        secretNoteFeedback
+    ) {
+        const SECRET_NOTE_KEY = 'cantinho-da-lari-secret-note';
+        let estaRevelado = false;
+
+        const sincronizarBotaoRevelar = () => {
+            secretNoteRevealBtn.textContent = estaRevelado ? 'Esconder segredinho' : 'Mostrar segredinho';
+            secretNoteRevealBtn.setAttribute('aria-pressed', estaRevelado.toString());
+        };
+
+        const atualizarSecretNoteDisplay = (manterRevelado = false) => {
+            const notaGuardada = localStorage.getItem(SECRET_NOTE_KEY);
+
+            if (!notaGuardada) {
+                secretNoteDisplay.textContent = 'Nenhum segredinho guardado ainda. Escreva algo fofo e clique em guardar!';
+                secretNoteDisplay.classList.remove('has-note', 'reveal');
+                secretNoteRevealBtn.disabled = true;
+                estaRevelado = false;
+                sincronizarBotaoRevelar();
+                return;
+            }
+
+            secretNoteDisplay.textContent = notaGuardada;
+            secretNoteDisplay.classList.add('has-note');
+            secretNoteRevealBtn.disabled = false;
+
+            if (manterRevelado) {
+                estaRevelado = true;
+            }
+
+            secretNoteDisplay.classList.toggle('reveal', estaRevelado);
+            sincronizarBotaoRevelar();
+        };
+
+        secretNoteSaveBtn.addEventListener('click', () => {
+            const conteudo = secretNoteTextarea.value.trim();
+
+            if (!conteudo) {
+                secretNoteFeedback.textContent = 'Escreva um segredinho antes de guardar. 😊';
+                return;
+            }
+
+            localStorage.setItem(SECRET_NOTE_KEY, conteudo);
+            secretNoteTextarea.value = '';
+            estaRevelado = true;
+            secretNoteFeedback.textContent = 'Segredinho guardado com carinho! 💌';
+            atualizarSecretNoteDisplay(true);
+        });
+
+        secretNoteClearBtn.addEventListener('click', () => {
+            localStorage.removeItem(SECRET_NOTE_KEY);
+            secretNoteTextarea.value = '';
+            secretNoteFeedback.textContent = 'Segredinho apagado. Quando quiser, escreva outro! ✨';
+            estaRevelado = false;
+            atualizarSecretNoteDisplay();
+        });
+
+        secretNoteRevealBtn.addEventListener('click', () => {
+            if (secretNoteRevealBtn.disabled) {
+                return;
+            }
+
+            estaRevelado = !estaRevelado;
+            secretNoteDisplay.classList.toggle('reveal', estaRevelado);
+            sincronizarBotaoRevelar();
+        });
+
+        atualizarSecretNoteDisplay();
+    }
 
 
     // --- FUNÇÃO REUTILIZÁVEL PARA ENVIAR NOTIFICAÇÕES ---

--- a/style.css
+++ b/style.css
@@ -410,6 +410,61 @@ html {
     transition: all 0.2s ease-in-out;
 }
 
+/* --- ESTILOS PARA O SECRETNOTE --- */
+#cantinho-secret-note textarea {
+    min-height: 140px;
+    resize: vertical;
+}
+
+.secret-note-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    justify-content: center;
+    margin-bottom: 15px;
+}
+
+.btn-outline {
+    background-color: transparent;
+    color: var(--cor-principal);
+    border: 2px solid var(--cor-principal);
+}
+
+.btn-outline:hover {
+    background-color: var(--cor-principal);
+    color: #fff;
+}
+
+.secret-note-display {
+    margin-top: 10px;
+    padding: 15px;
+    border-radius: var(--borda-radius);
+    border: 1px dashed #fde7f3;
+    background: rgba(255, 249, 251, 0.8);
+    min-height: 60px;
+    font-weight: 600;
+    filter: blur(7px);
+    transition: filter 0.4s ease, background 0.3s ease;
+}
+
+.secret-note-display.has-note {
+    background: rgba(255, 249, 251, 0.95);
+}
+
+.secret-note-display.reveal {
+    filter: none;
+}
+
+.secret-note-display:not(.has-note) {
+    filter: none;
+    font-style: italic;
+    color: #777;
+}
+
+#secret-note-feedback {
+    min-height: 20px;
+}
+
 .nav-button:hover {
     background-color: var(--cor-principal);
     color: white;


### PR DESCRIPTION
## Summary
- add richer SEO metadata and navigation updates, including a new SecretNote card with styling and local storage support
- enhance the relationship counter to show a live breakdown from 24/10/2024 and expose a robots.txt for crawlers
- configure npm scripts and a GitHub Actions workflow so CI runs linting on pushes and pull requests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3e38f55408324bf2f95671b272456